### PR TITLE
Allow passing in `:verify_ssl` as an option

### DIFF
--- a/lib/arista/eapi/request.rb
+++ b/lib/arista/eapi/request.rb
@@ -1,14 +1,15 @@
 module Arista
   module EAPI
     class Request
-      attr_accessor :switch, :commands, :options
+      attr_accessor :switch, :commands, :options, :verify_ssl
 
-      def initialize(switch, commands, options = {})
+      def initialize(switch, commands, options = {}, verify_ssl=true)
         options[:format] ||= 'json'
 
         self.switch = switch
         self.commands = commands
         self.options = options
+        self.verify_ssl = verify_ssl
       end
 
       def payload
@@ -25,7 +26,12 @@ module Arista
       end
 
       def execute
-        Arista::EAPI::Response.new(commands, RestClient.post(switch.url, payload))
+        req = RestClient::Resource.new(
+          switch.url,
+          payload,
+          :verify_ssl       =>  self.verify_ssl
+        )
+        Arista::EAPI::Response.new(commands, req.post)
       end
     end
   end

--- a/lib/arista/eapi/version.rb
+++ b/lib/arista/eapi/version.rb
@@ -1,5 +1,5 @@
 module Arista
   module EAPI
-    VERSION = "0.11.6"
+    VERSION = "0.11.7"
   end
 end


### PR DESCRIPTION
**Allow passing in `:verify_ssl` as an option**
This is to allow clients to have the option to pass in `:verify_ssl` as
an option when making requests.
